### PR TITLE
Fix: Correct Vercel deployment configuration

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,3 @@
 // api/index.ts
-import app from "../server/index.ts";
+import app from "../dist/server/index.js";
 export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,13 @@
 {
   "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist/public",
+  "functions": {
+    "api/index.ts": {
+      "runtime": "nodejs20.x"
+    }
+  },
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/index.ts" },
+    { "source": "/api/(.*)", "destination": "/api" },
     { "source": "/((?!api).*)", "destination": "/" }
   ],
   "env": {


### PR DESCRIPTION
This commit resolves a Vercel deployment failure by making two key corrections:

1.  **Update API Import Path:** The serverless function entry point `api/index.ts` was incorrectly importing the TypeScript source file `../server/index.ts`. This has been changed to import the compiled JavaScript artifact `../dist/server/index.js`, which is the correct module to use in the Node.js runtime environment on Vercel.

2.  **Refine `vercel.json`:** The Vercel configuration has been updated to be more explicit and robust. It now includes a `functions` block to specify the Node.js runtime version for the API endpoint. The API rewrite rule destination has been set to `/api` in conjunction with this more explicit configuration.

These two changes together ensure that the serverless function is built correctly and that all modules are resolved properly at runtime.