### PR TITLE
Fix(server): Correct static asset path in production

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,7 +68,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname, "..", "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
This commit resolves a runtime error where the server would crash on startup in the Vercel environment.

The root cause was an incorrect path resolution in `server/vite.ts`. The `serveStatic` function was looking for the `dist/public` directory in the wrong location (`dist/server/public`).

This has been corrected by changing the path resolution from `path.resolve(import.meta.dirname, "public")` to `path.resolve(import.meta.dirname, "..", "public")`. This ensures the server correctly navigates up one level from `dist/server` to `dist` before looking for the `public` directory.

This change, combined with the previous fixes to `vercel.json` and `api/index.ts`, should provide the final, stable configuration for Vercel deployment.