### PR TITLE
fix: Synchronize educational categories and separate content types

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import ExerciseDetail from "@/pages/exercise-detail";
 // import RelaxationExercises from "@/pages/relaxation-exercises";
 import Tracking from "@/pages/tracking";
 import Education from "@/pages/education";
+import Library from "@/pages/library";
 import Profile from "@/pages/profile";
 import Login from "@/pages/login";
 import NotFound from "@/pages/not-found";
@@ -78,6 +79,11 @@ function AppContent() {
       <Route path="/education">
         <ProtectedRoute>
           <Education />
+        </ProtectedRoute>
+      </Route>
+      <Route path="/library">
+        <ProtectedRoute>
+          <Library />
         </ProtectedRoute>
       </Route>
       <Route path="/profile">

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -60,6 +60,13 @@ export function Navigation() {
               )} data-testid="nav-education">
                 Éducation
               </Link>
+              <Link to="/library" className={cn("px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                isActive("/library") 
+                  ? "bg-primary text-primary-foreground" 
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              )} data-testid="nav-library">
+                Bibliothèque
+              </Link>
 
               {user?.role === 'admin' && (
                 <Link to="/admin" className={cn("px-3 py-2 rounded-lg text-sm font-medium transition-colors",
@@ -84,7 +91,7 @@ export function Navigation() {
 
       {/* Bottom navigation for mobile */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-card border-t border-border z-40">
-        <div className={cn("grid h-16", user?.role === 'admin' ? 'grid-cols-6' : 'grid-cols-5')}>
+        <div className={cn("grid h-16", user?.role === 'admin' ? 'grid-cols-7' : 'grid-cols-6')}>
           <Link to="/" className={cn("flex flex-col items-center justify-center space-y-1 transition-colors",
             isActive("/") ? "text-primary" : "text-muted-foreground hover:text-primary"
           )} data-testid="nav-mobile-home">
@@ -109,6 +116,12 @@ export function Navigation() {
           )} data-testid="nav-mobile-education">
             <span className="material-icons text-lg">school</span>
             <span className="text-xs">Éducation</span>
+          </Link>
+          <Link to="/library" className={cn("flex flex-col items-center justify-center space-y-1 transition-colors",
+            isActive("/library") ? "text-primary" : "text-muted-foreground hover:text-primary"
+          )} data-testid="nav-mobile-library">
+            <span className="material-icons text-lg">library_books</span>
+            <span className="text-xs">Bibliothèque</span>
           </Link>
           <Link to="/profile" className={cn("flex flex-col items-center justify-center space-y-1 transition-colors",
             isActive("/profile") ? "text-primary" : "text-muted-foreground hover:text-primary"


### PR DESCRIPTION
### **User description**
✨ Corrections apportées:

🔧 Page Éducation (education.tsx):
- Utilisation prioritaire des nouvelles APIs (educational-contents, content-categories)
- Fallback intelligent vers l'ancien système (psycho-education)
- Chargement automatique des catégories dynamiques
- Meilleure gestion des états de chargement

📚 Bibliothèque (library.tsx):
- Réorganisation complète avec séparation claire des types de contenu
- 4 onglets distincts: Contenu Éducatif, Exercices, Séances, Tout Voir
- Utilisation des catégories appropriées pour chaque type
- Filtrage dynamique selon l'onglet actif
- Interface utilisateur cohérente et intuitive

🧭 Navigation (navigation.tsx):
- Ajout du lien 'Bibliothèque' dans le menu desktop et mobile
- Adaptation de la grille mobile pour 6/7 colonnes selon le rôle

🛤️  Routes (App.tsx):
- Ajout de la route '/library' manquante
- Import du composant Library

🎯 Problèmes résolus:
- ✅ Catégories incohérentes entre admin et patient dans l'éducatif
- ✅ Contenus créés côté admin non visibles côté patient
- ✅ Confusion entre exercices et séances dans la bibliothèque
- ✅ Chargement automatique du contenu lors de l'ouverture des onglets

🔗 Synchronisation des systèmes:
- Admin utilise: educational-contents + content-categories (nouveau)
- Patient utilise: même système avec fallback vers psycho-education (legacy)
- Exercices: utilisation des EXERCISE_CATEGORIES partagées
- Séances: utilisation des SESSION_CATEGORIES partagées


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Synchronize educational content categories between admin and patient views

- Reorganize library with separate tabs for educational content, exercises, and sessions

- Add library navigation link and route

- Implement intelligent fallback system for content loading


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Admin System"] --> B["New Educational API"]
  B --> C["Patient Education Page"]
  C --> D["Fallback to Legacy API"]
  E["Library Page"] --> F["Educational Content Tab"]
  E --> G["Exercises Tab"]
  E --> H["Sessions Tab"]
  I["Navigation"] --> J["Library Link Added"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Add library route and component import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/App.tsx

<ul><li>Import <code>Library</code> component<br> <li> Add <code>/library</code> route with protected access</ul>


</details>


  </td>
  <td><a href="https://github.com/doriansarry47-creator/apaddicto/pull/19/files#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation.tsx</strong><dd><code>Add library navigation links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/navigation.tsx

<ul><li>Add "Bibliothèque" link to desktop navigation<br> <li> Add library icon to mobile navigation<br> <li> Adjust mobile grid columns for 6/7 layout</ul>


</details>


  </td>
  <td><a href="https://github.com/doriansarry47-creator/apaddicto/pull/19/files#diff-f9473cbf8b534a30e8eff31e0c6e3680f1c2011fa5acae4323c135fb1dbee049">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>library.tsx</strong><dd><code>Reorganize library with content type separation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/pages/library.tsx

<ul><li>Complete reorganization with 4 distinct tabs<br> <li> Separate educational content, exercises, and sessions<br> <li> Use appropriate categories for each content type<br> <li> Dynamic filtering based on active tab<br> <li> Consistent UI components for each content type</ul>


</details>


  </td>
  <td><a href="https://github.com/doriansarry47-creator/apaddicto/pull/19/files#diff-8225c53ace7c8c6d8da99d9285e9b6d33a4e971cc7e2905557de98f46202d70c">+378/-134</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>education.tsx</strong><dd><code>Synchronize educational content APIs with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/pages/education.tsx

<ul><li>Prioritize new educational-contents API over legacy<br> <li> Implement intelligent fallback to psycho-education API<br> <li> Load categories first, then content<br> <li> Improve loading states and error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/doriansarry47-creator/apaddicto/pull/19/files#diff-87f5c5c03521c7d4d27c7001b2d408721c595eb18a19c204337180de6132072d">+46/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Nouveautés
  - Nouvelle page Bibliothèque avec quatre onglets (Contenu éducatif, Exercices, Séances, Tout voir), filtres par catégorie, cartes dédiées, statistiques rapides et gestion des états de chargement.
  - Navigation mise à jour: ajout du lien Bibliothèque sur desktop et mobile; nouvelle route protégée /library.
- Améliorations
  - Page Éducation plus résiliente: chargement des catégories priorisé, sélection par défaut, conversion enrichie des contenus et messages contextualisés selon la source.
  - Fallbacks automatiques vers contenus hérités ou statiques si la nouvelle source est indisponible, tout en conservant le suivi de progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->