### PR TITLE
fix: correct TypeScript error TS2353 and improve build chunking

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1038,17 +1038,34 @@ export function registerRoutes(app: Application) {
   app.post('/api/patient-sessions/favorites', requireAuth, async (req, res) => {
     try {
       const userId = req.session.user!.id;
-      const { sessionId, customName, customizedData } = req.body;
+      const { sessionId, customName, customizedData, title, category, description, exercises, protocol, totalDuration, difficulty, tags, imageUrl } = req.body;
 
-      if (!sessionId) {
-        return res.status(400).json({ message: 'Session ID requis' });
+      if (!sessionId && !title) {
+        return res.status(400).json({ message: 'Session ID ou titre requis' });
+      }
+
+      // Si sessionId fourni, récupérer la session source pour obtenir ses données
+      let sessionData: any = null;
+      if (sessionId) {
+        const sessions = await storage.getSessions({
+          userId,
+          userRole: req.session.user!.role || 'patient',
+        });
+        sessionData = sessions.find((s: any) => s.id === sessionId);
       }
 
       const favoriteSession = await storage.addFavoriteSession({
         userId,
         sessionId,
-        customName,
-        customizedData
+        title: customName || title || sessionData?.title || 'Séance favorite',
+        description: description || sessionData?.description,
+        category: category || sessionData?.category || 'maintenance',
+        protocol: protocol || sessionData?.protocol,
+        totalDuration: totalDuration || sessionData?.totalDuration,
+        difficulty: difficulty || sessionData?.difficulty,
+        exercises: exercises || sessionData?.exercises || [],
+        tags: tags || sessionData?.tags,
+        imageUrl: imageUrl || sessionData?.imageUrl,
       });
 
       res.json(favoriteSession);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,9 +27,44 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, "dist"),
     emptyOutDir: true,
+    chunkSizeWarningLimit: 600,
     rollupOptions: {
-      input: path.resolve(__dirname, "client/index.html")
-    }
+      input: path.resolve(__dirname, "client/index.html"),
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom"],
+          "vendor-router": ["wouter"],
+          "vendor-ui": [
+            "@radix-ui/react-dialog",
+            "@radix-ui/react-dropdown-menu",
+            "@radix-ui/react-select",
+            "@radix-ui/react-tabs",
+            "@radix-ui/react-tooltip",
+            "@radix-ui/react-accordion",
+            "@radix-ui/react-alert-dialog",
+            "@radix-ui/react-avatar",
+            "@radix-ui/react-checkbox",
+            "@radix-ui/react-collapsible",
+            "@radix-ui/react-label",
+            "@radix-ui/react-popover",
+            "@radix-ui/react-progress",
+            "@radix-ui/react-radio-group",
+            "@radix-ui/react-scroll-area",
+            "@radix-ui/react-separator",
+            "@radix-ui/react-slider",
+            "@radix-ui/react-switch",
+            "@radix-ui/react-toggle",
+            "@radix-ui/react-toggle-group",
+          ],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-forms": ["react-hook-form", "@hookform/resolvers", "zod"],
+          "vendor-charts": ["recharts"],
+          "vendor-icons": ["lucide-react"],
+          "vendor-toast": ["sonner"],
+          "vendor-utils": ["date-fns", "clsx", "class-variance-authority", "tailwind-merge"],
+        },
+      },
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Corrections et améliorations

### 🐛 Correction erreur TypeScript (TS2353)
- **Fichier**: `server/routes.ts` ligne 1050
- **Erreur**: `Object literal may only specify known properties, and 'customName' does not exist in type`
- **Cause**: La route `POST /api/patient-sessions/favorites` passait les propriétés `customName` et `customizedData` à `storage.addFavoriteSession()`, mais cette méthode ne définit pas ces paramètres dans son interface TypeScript
- **Solution**: La route récupère maintenant les données de la session source via `sessionId`, puis crée la favorite avec les bonnes propriétés typées. Le `customName` est mappé vers le champ `title` (la propriété correcte)

### ⚡ Amélioration build (code splitting)
- **Fichier**: `vite.config.ts`
- Ajout de `manualChunks` pour diviser le bundle principal (~1.7MB) en plusieurs chunks plus petits:
  - `vendor-react`: React + React DOM
  - `vendor-ui`: Composants Radix UI
  - `vendor-query`: TanStack Query
  - `vendor-forms`: React Hook Form + Zod
  - `vendor-charts`: Recharts
  - `vendor-icons`: Lucide React
  - `vendor-toast`: Sonner
  - `vendor-utils`: date-fns, clsx, tailwind-merge
- Ajout de `chunkSizeWarningLimit: 600` pour réduire les avertissements de build

### Tests
- La compilation TypeScript de `server/routes.ts` ne retourne plus d'erreurs TS2353
- La route favorites accepte maintenant aussi bien un `sessionId` seul qu'une combinaison de données directes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Améliorations**
  * Les sessions préférées conservent maintenant plus d'informations (titre, catégorie, description, exercices, durée totale, niveau de difficulté, étiquettes et images).
  * Optimisation des performances de l'application grâce à un meilleur regroupement des dépendances lors de la compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->